### PR TITLE
Update Travis to use `npm install` instead of `npm ci`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "10"
 before_install:
   - rm -f package-lock.json
-script: npm run build
+script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
-   - "10"
+  - "10"
+before_install:
+  - rm -f package-lock.json
 script: npm run build


### PR DESCRIPTION
This PR attempts to fix the Travis CI failures related to the `npm ci` command. Since our package-lock file only contains production modules, npm ci fails since it considers it out-of-sync with package.json. This PR deletes the package-lock in the travis before_install hook in hopes of having travis use `npm install` instead of `npm ci` for the install step.


From the travis docs:

> If package-lock.json or npm-shrinkwrap.json exists and your npm version supports it, Travis CI will use npm ci instead of npm install.

https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#npm-ci-support