### PR TITLE
Utilize npx and node eval option

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=http://registry.npmjs.com/
+registry=https://registry.npmjs.com/

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
   ],
   "readmeFilename": "README.md",
   "devDependencies": {
-    "check-node-version": "^3.2.0",
+    "check-node-version": "^4.0.3",
+    "flow-bin": "^0.85.0",
     "fs-extra": "^5.0.0",
     "grumbler-scripts": "^2",
-    "npm": "^6.14.0",
-    "flow-bin": "^0.85.0"
+    "npm": "^6.14.0"
   },
   "dependencies": {
     "@paypal/card-components": "1.0.45",

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -9,11 +9,11 @@ version="$1";
 tag="active";
 defenvs="test local stage sandbox production";
 
-module=$(cat << EOF | node
+module=$(node --eval "
     const PACKAGE = './package.json';
     let pkg = require(PACKAGE);
     console.log(pkg.name);
-EOF);
+")
 
 if [ -z "$version" ]; then
     version=$(npm view $module version);

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -6,13 +6,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 $DIR/validate.sh;
 
 if [ -z "$1" ]; then
-    $(npm bin)/npm-check-updates --prod --upgrade
+    npx npm-check-updates --prod --upgrade
 else
     if ! npm ls "$1"; then
         npm install --only=production --production --save --save-exact "$1"
         $DIR/prune.sh;
     else
-        $(npm bin)/npm-check-updates --prod --upgrade --filter="$1"
+        npx npm-check-updates --prod --upgrade --filter="$1"
     fi;
 fi;
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -12,7 +12,7 @@ if ! git diff-index --quiet --cached HEAD; then
     exit 1;
 fi;
 
-node $(npm bin)/check-node-version --node='>=12' --npm='>=6.14';
+npx check-node-version --node='>=12' --npm='>=6.14';
 
 UPSTREAM='origin'
 LOCAL=$(git rev-parse @)


### PR DESCRIPTION
I make some minor tweaks as I was reviewing the code in this project:
- Utilize npx over `$(npm bin)`
- Use `node --eval` to evaluate js inline in a bash script. The current approach works but breaks the bash formatting in my editor.
- Use https for npm registry
- Upgrade npm-check-updates dev dependency