### PR TITLE
Manage the cdn folder in with release script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10.13, 12, 14]
+        node: [12, 14]
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "add": "grabthar-add",
     "upgrade": "grabthar-upgrade",
     "remove": "grabthar-remove",
-    "release": "grabthar-release",
+    "release": "grabthar-release && npm run cdnify -- --commitonly",
     "activate": "CDN='https://www.paypalobjects.com' grabthar-activate",
     "flatten": "grabthar-flatten",
     "full-release": "npm run upgrade && npm run release && npm run activate",


### PR DESCRIPTION
This PR updates `npm run release` to update the cdn folder in this repo without staging the bundle.