### PR TITLE
Remove optional argument for `npm run release` from `workflow_dispatch`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: publish to npm
-on:
-  # manually run this action using the GitHub UI
-  # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
-  workflow_dispatch:
+# manually run this action using the GitHub UI
+# https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+on: workflow_dispatch
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,6 @@ on:
   # manually run this action using the GitHub UI
   # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
   workflow_dispatch:
-    inputs:
-      version:
-        description: Optional argument for "npm run release"
-        required: false
-        default: 'patch'
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -33,7 +28,7 @@ jobs:
           git config --global user.name ${{ github.actor }}
 
       - name: Publish to npm
-        run: npm run release -- ${{ github.event.inputs.version }}
+        run: npm run release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Purpose

This PR removes the optional argument for `npm run release` from the `workflow_dispatch` event, since we always do patch releases:

<img width="1239" alt="Screen Shot 2021-09-15 at 10 11 43 AM" src="https://user-images.githubusercontent.com/20399044/133478835-0c2a8056-8038-418a-9344-2ea5af361f05.png">