### PR TITLE
Add the correct repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/krakenjs/grumbler.git"
+    "url": "git://github.com/paypal/paypal-sdk-release.git"
   },
   "keywords": [
     "template"


### PR DESCRIPTION
### Problem

@wsbrunson pointed out an incorrect repository URL at https://www.npmjs.com/package/@paypal/sdk-release during today's JS SDK release.

### Solution

Updated the URL to point to the correct repo.