### PR TITLE
create a do nothing deploy script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,36 @@
         "jsx-pragmatic": "^2"
       }
     },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "beaver-logger": {
       "version": "4.0.32",
       "resolved": "https://registry.npmjs.org/beaver-logger/-/beaver-logger-4.0.32.tgz",
@@ -186,6 +216,17 @@
         "cross-domain-safe-weakmap": "^1",
         "cross-domain-utils": "^2",
         "zalgo-promise": "^1"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "bowser": {
@@ -210,6 +251,16 @@
         "restricted-input": "1.2.7"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "card-validator": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-4.3.0.tgz",
@@ -217,6 +268,64 @@
       "requires": {
         "credit-card-type": "^6.2.0"
       }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "core-js-pure": {
       "version": "3.19.0",
@@ -244,25 +353,193 @@
         "zalgo-promise": "^1.0.11"
       }
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
     "framebus": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/framebus/-/framebus-3.0.1.tgz",
       "integrity": "sha1-26vDsI45vzPSSOmvdUvY/7Bc/M4="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "hi-base32": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
       "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
     "inject-stylesheet": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/inject-stylesheet/-/inject-stylesheet-1.0.0.tgz",
       "integrity": "sha1-9nMEdFjuWPEJ/uTPtmsJ82LMwmE="
     },
+    "inquirer": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.2.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
     "jsx-pragmatic": {
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/jsx-pragmatic/-/jsx-pragmatic-2.0.22.tgz",
       "integrity": "sha512-3AeehQzwirOTarn+cXVsjWfpJu4AzQuzPlze6JC53MQj59VwC1uLWCB+rsL9riFmemHw2ZF9Y7mRKCMZRitf4g=="
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "post-robot": {
       "version": "10.0.44",
@@ -281,6 +558,27 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.0.2.tgz",
       "integrity": "sha512-iKg9hghcMQQOnb/n12cR/zs4WBEM3f9s4gOBHH7pSt+XhZQrwIHAvuN+P541hy1kiBQggZiX874BOSgHgt90Vw=="
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "restricted-input": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/restricted-input/-/restricted-input-1.2.7.tgz",
@@ -289,10 +587,123 @@
         "@braintree/browser-detection": "^1.5.0"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "dev": true,
+      "requires": {
+        "tslib": "~2.1.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true
+    },
     "universal-serialize": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/universal-serialize/-/universal-serialize-1.0.10.tgz",
       "integrity": "sha512-FdouA4xSFa0fudk1+z5vLWtxZCoC0Q9lKYV3uUdFl7DttNfolmiw2ASr5ddY+/Yz6Isr68u3IqC9XMSwMP+Pow=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
     },
     "whatwg-fetch": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -54,10 +54,12 @@
   "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "grabthar-release": "^1",
+    "chalk": "4.1.2",
     "flow-bin": "0.135.0",
+    "flowgen": "1.11.0",
+    "grabthar-release": "^1",
     "grumbler-scripts": "^3",
-    "flowgen": "1.11.0"
+    "inquirer": "8.2.0"
   },
   "dependencies": {
     "@paypal/card-components": "1.0.48",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+const inquirer = require("inquirer");
+const chalk = require("chalk");
+
+/**
+ *
+ * Ideas for future enhancement:
+ * - Generate full change log (version changes)
+ * - poll this url to detect when changes are in production: https://www.paypalobjects.com/js-sdk-release/paypal/sdk-release/info.json
+ * - verify cdnx bundle version for the script runner (curl https://uideploy--staticcontent--${bundleId}--ghe.preview.dev.paypalinc.com/js-sdk-release/paypal/sdk-release/info.json),
+ *   parse it, and verify version numbers match the right tags
+ * - kick off GH actions from cli and monitor their progress before moving on
+ * - use Slack API to automatically post messages
+ * - display pre-reqs if user has never done a deploy
+ * - save script progress, ask to continue or clear if script exits early
+ */
+
+/* Utilities */
+
+const waitForEnter = () =>
+  inquirer.prompt([{ message: "Press Enter to continue", name: "continue" }]);
+
+const log = (input) => console.log(`${input}\n`);
+
+const link = (input) => chalk.underline(chalk.blue(input));
+const warning = (input) => chalk.yellow(input);
+
+const getCdnxInfoJsonFile = (bundleId) =>
+  `https://uideploy--staticcontent--${bundleId}--ghe.preview.dev.paypalinc.com/js-sdk-release/paypal/sdk-release/info.json`;
+
+class Context {
+  constructor() {
+    this.values = {};
+  }
+
+  get(key) {
+    return this.values[key];
+  }
+
+  set(key, value) {
+    this.values[key] = value;
+  }
+}
+
+/* Steps */
+
+const notifyTeamOfDeploymentStart = () => {
+  log(`
+  Send the following message to the ${chalk.bold("#js-sdk-dev")} channel:\n
+  :clapper: Starting prep for JS SDK release :soon: `);
+
+  return waitForEnter();
+};
+
+const upgradeSdkDependencies = () => {
+  log(`
+  Upgrade dependencies for the SDK using the following Github Action:\n
+  ${link(
+    "https://github.com/paypal/paypal-sdk-release/actions/workflows/upgrade.yml\n"
+  )}
+  ${warning(
+    "Wait for the Github Action to complete before moving to the next step"
+  )}`);
+
+  return waitForEnter();
+};
+
+// TODO:
+// Enter the new sdk version in this step
+const publishSdkToNpm = () => {
+  log(`
+  Publish the SDK to the npm registry using the following Github Action:\n
+  ${link(
+    "https://github.com/paypal/paypal-sdk-release/actions/workflows/publish.yml\n"
+  )}
+  ${warning(
+    "Wait for the Github Action to complete before moving to the next step"
+  )}`);
+
+  return waitForEnter();
+};
+
+// TODO:
+// Enter the bundle id during this step
+const runJenkinsJobToGenerateFirstBundle = () => {
+  log(`
+  Build the following Jenkins job to create the first sdk bundle. Make sure GIT_REPOSITORY is set to https://github.com/paypal/paypal-sdk-release\n
+  ${link(
+    "https://ci.paypalcorp.com/HermesRelease/job/Stage-Assets-QA-CDN/build?delay=0sec\n"
+  )}
+  You should receive an email from assetdeploy-notifications@gcp.dev.paypalinc.com with a link to the bundles on CDNX.\n
+  ${warning("Wait for this email before preceding.")}\n
+  If you don't receive an email a few minutes after the Jenkins job finishes, check with other deployers.`);
+
+  return waitForEnter();
+};
+
+const activateNpmDistTags = () => {
+  log(`
+  Activate the npm dist tags for the sdk using the following Github Action:\n
+  ${link(
+    "https://github.com/paypal/paypal-sdk-release/actions/workflows/activate.yml\n"
+  )}
+  ${warning(
+    "Wait for the Github Action to complete before moving to the next step"
+  )}`);
+
+  return waitForEnter();
+};
+
+// TODO:
+// Enter the bundle id during this step
+const runJenkinsJobToGenerateSecondBundle = () => {
+  log(`
+  Build the following Jenkins job to create the second sdk bundle. Make sure GIT_REPOSITORY is set to https://github.com/paypal/paypal-sdk-release\n
+  ${link(
+    "https://ci.paypalcorp.com/HermesRelease/job/Stage-Assets-QA-CDN/build?delay=0sec\n"
+  )}
+  You should receive an email from assetdeploy-notifications@gcp.dev.paypalinc.com with a link to the bundles on CDNX.\n
+  ${warning("Wait for this email before preceding.")}\n
+  If you don't receive an email a few minutes after the Jenkins job finishes, check with other deployers.`);
+
+  return waitForEnter();
+};
+
+const validateFirstBundleOnCdnx = async (context) => {
+  const { firstBundleId } = await inquirer.prompt([
+    { name: "firstBundleId", message: "Enter the first bundle id" },
+  ]);
+
+  context.set("firstBundleId", firstBundleId);
+
+  log(`
+  Navigate to the ${chalk.bold("first")} CDNX bundle link.\n
+  ${link(getCdnxInfoJsonFile(firstBundleId))}\n
+  Ensure the expected SDK version number in "dist-tags" is set for:\n
+  "latest", "active-test", "active-local", and "active-stage"`);
+
+  return waitForEnter();
+};
+
+const validateSecondBundleOnCdnx = async (context) => {
+  const { secondBundleId } = await inquirer.prompt([
+    { name: "secondBundleId", message: "Enter the second bundle id" },
+  ]);
+
+  context.set("secondBundleId", secondBundleId);
+
+  log(`
+  Navigate to the ${chalk.bold("second")} CDNX bundle link.\n
+  ${link(getCdnxInfoJsonFile(secondBundleId))}\n
+  Ensure the expected SDK version number in "dist-tags" is set for:\n
+  "latest", "active-test", "active-local", "active-stage", "active-sandbox" and "active-production" `);
+
+  return waitForEnter();
+};
+
+const validateJavascriptInBundles = () => {
+  log(`
+  Do the following steps to verify the JavaScript of ${chalk.bold(
+    "both"
+  )} bundles
+
+  * Run clientsdknodeweb locally
+  * Change BUNDLE_ID_GOES_HERE in the index.html file under /scripts/index.html to the bundle id to test
+  * Serve it: cd ./scripts && ruby -run -e httpd . -p 2000
+  * Make sure you can click the PayPal button, that the pop-up opens, and that there are no JS errors`);
+
+  return waitForEnter();
+};
+
+const updateChangelog = async (context) => {
+  const { newVersion, previousVersion } = await inquirer.prompt([
+    {
+      name: "previousVersion",
+      message: "Enter the previous sdk version number",
+    },
+    { name: "newVersion", message: "Enter the new sdk version number" },
+  ]);
+
+  const firstBundleId = context.get("firstBundleId");
+  const secondBundleId = context.get("secondBundleId");
+  log(`
+  The change log is located here:\n
+  ${link(
+    "https://engineering.paypalcorp.com/confluence/pages/viewpage.action?spaceKey=Checkout&title=JS+SDK+CDNX+Changelog"
+  )}\n
+  Create a new row in the table. It's easiest to copy the last row and paste it. Change the date to today's date and version to the current version.
+  Use the following for CDNX Bundle IDs Column. Note that Confluence doesn't work well with pasting links, you'll have to build them yourself.\n
+  1. [Bundle ID: ${firstBundleId}|https://cdnx-ui.qa.paypal.com/bundles/${firstBundleId}]
+    a. when deployed to production this bundle will queue up the new release.
+    b. Stage Environment for testing changes
+      i. [JS SDK URL|https://www.msmaster.qa.paypal.com/sdk/js?client-id=alc_client1&debug=true&cdn-registry=https://uideploy--staticcontent--${firstBundleId}--ghe.preview.dev.paypalinc.com/js-sdk-release&version=${newVersion}]
+      ii. [SDK Release Info.json|https://uideploy--staticcontent--${firstBundleId}--ghe.preview.dev.paypalinc.com/js-sdk-release/paypal/sdk-release/info.json]
+  2. [Bundle ID: ${secondBundleId}|https://cdnx-ui.qa.paypal.com/bundles/${secondBundleId}]
+    a. when deployed to production this bundle will activate the new release.
+    b. Stage Environment for testing changes
+      i. [JS SDK URL|https://www.msmaster.qa.paypal.com/sdk/js?client-id=alc_client1&debug=true&cdn-registry=https://uideploy--staticcontent--${secondBundleId}--ghe.preview.dev.paypalinc.com/js-sdk-release]
+      ii. [SDK Release Info.json|https://uideploy--staticcontent--${secondBundleId}--ghe.preview.dev.paypalinc.com/js-sdk-release/paypal/sdk-release/info.json]
+   
+  To fill out the code changelog do the following:
+  Go to the following url and find the package-lock.json file:\n
+  ${link(
+    `https://github.com/paypal/paypal-sdk-release/compare/v${previousVersion}...v${newVersion}`
+  )}\n
+  Make note of all the packages with changed versions and log them
+  For every changed package, create a new row  in the App/Contributor table like this:
+  App                                                                           Contributer
+  ---                                                                           ---
+  https://github.com/REPO_OWNER/REPO_NAME/compare/vOLD_VERSION...vNEW_VERSION | @ConfluenceName of anyone who commited (if possible)\n
+  Once the changelog is complete, post the following message to ${chalk.bold(
+    "#js-sdk-dev"
+  )}:\n
+:announcement: JS SDK Release candidate ${newVersion} is ready for testing in Stage. :announcement-r:
+The cdnx bundle ids and stage testing urls are documented here: https://engineering.paypalcorp.com/confluence/display/Checkout/JS+SDK+CDNX+Changelog. As a reminder, we’d like all contributors to sign-off on these two bundle ids in the stage environment at the confluence link above.`);
+
+  return waitForEnter();
+};
+
+const engageCommandCenter = () => {
+  log("TODO: Implement this step");
+};
+
+const approveFirstBundle = () => {
+  log("TODO: Implement this step");
+};
+
+const deployFirstBundle = () => {
+  log("TODO: Implement this step");
+};
+const deployFirstBundle = () => {
+  log("TODO: Implement this step");
+};
+const verifyFirstBundle = () => {
+  log("TODO: Implement this step");
+};
+const approveSecondBundle = () => {
+  log("TODO: Implement this step");
+};
+const deploySecondBundle = () => {
+  log("TODO: Implement this step");
+};
+const verifySecondBundle = () => {
+  log("TODO: Implement this step");
+};
+
+const steps = [
+  notifyTeamOfDeploymentStart,
+  upgradeSdkDependencies,
+  publishSdkToNpm,
+  runJenkinsJobToGenerateFirstBundle,
+  activateNpmDistTags,
+  runJenkinsJobToGenerateSecondBundle,
+  validateFirstBundleOnCdnx,
+  validateSecondBundleOnCdnx,
+  validateJavascriptInBundles,
+  updateChangelog,
+  engageCommandCenter,
+  approveFirstBundle,
+  deployFirstBundle,
+  deployFirstBundle,
+  verifyFirstBundle,
+  approveSecondBundle,
+  deploySecondBundle,
+  verifySecondBundle,
+];
+
+(async function () {
+  const context = new Context();
+  for (const step of steps) {
+    await step(context);
+  }
+})();

--- a/scripts/index.html
+++ b/scripts/index.html
@@ -1,0 +1,40 @@
+<!-- Use this index.html file to help validate sdk bundles on CDNX before they are deployed -->
+<!DOCTYPE html>
+<body>
+    <h1>Venmo Desktop Test Page</h1>
+    <div id="paypal-button-container"></div>
+
+    <!-- Use this script tag for bundle 1. Make sure to include version number at the end -->
+    <!-- <script src="https://localhost.paypal.com:8443/sdk/js?client-id=alc_client1&debug=true&cdn-registry=https://uideploy--staticcontent--BUNDLE_ID_GOES_HERE--ghe.preview.dev.paypalinc.com/js-sdk-release&version=VERSION_GOES_HERE"></script> -->
+
+    <!-- Use this script tag for bundle 2 -->
+    <!-- <script src="https://localhost.paypal.com:8443/sdk/js?client-id=alc_client1&debug=true&cdn-registry=https://uideploy--staticcontent--BUNDLE_ID_GOES_HERE--ghe.preview.dev.paypalinc.com/js-sdk-release"></script> -->
+
+    <script>
+        paypal
+            .Buttons({
+                createOrder: function (data, actions) {
+                    return actions.order.create({
+                        purchase_units: [
+                            {
+                                amount: {
+                                    value: "0.01",
+                                },
+                            },
+                        ],
+                    });
+                },
+                onApprove: function (data, actions) {
+                    return actions.order.capture().then(function (details) {
+                        alert(
+                            "Transaction completed by " +
+                                details.payer.name.given_name +
+                                "!"
+                        );
+                    });
+                },
+                // enableNativeCheckout: true
+            })
+            .render("#paypal-button-container");
+    </script>
+</body>


### PR DESCRIPTION
Based on this great article (its a short read, I promise): https://blog.danslimmon.com/2019/07/15/do-nothing-scripting-the-key-to-gradual-automation/

A big portion of the sdk deploy process has been automated using Github Actions but there are still a few manual steps. These manual steps require the human operator to 1. execute them in order and 2. be very careful to reference the correct bundle ids sdk version numbers for each step. I've done the deploy twice and both times I've ended up with many tabs that I have to try to keep in order as to which bundle  they reference.

The current iteration of this script does not automate anything. We are documenting how each step of the deploy process works, what comes next, and saving the user's place should they take a break. In the validating the bundles step, we are asking for the user to input bundle ids so we can help them check the right ones. In generating the change log, we are also asking for previous and next sdk versions so they can be sure they are generating the right urls for the change log so that contributors are validating the correct bundles on stage. 

The goal would be to finish implementing the rest of the steps of the deploy process as they are in their current form. Once we are satisfied that this script can adequately walk a deployer through the sdk deployment process, we can start adding more automation. I've listed out some ideas at the top of the deploy.js file that we could start with. Some really easy wins would be automating the slack messages and kicking off github actions from the command line.