### PR TITLE
`zx` changes

### DIFF
--- a/.github/workflows/activate.yml
+++ b/.github/workflows/activate.yml
@@ -32,7 +32,7 @@ jobs:
           git config --global user.name ${{ github.actor }}
 
       - name: Activate npm dist tags
-        run: npm run activate -- ${{ github.event.inputs.version }}
+        run: npm run activate --LOCAL_VERSION=${{ github.event.inputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -31,4 +31,4 @@ jobs:
           git config --global user.name ${{ github.actor }}
 
       - name: 🍏 Upgrade dependencies
-        run: npm run upgrade -- ${{ github.event.inputs.filter }}
+        run: npm run upgrade --MODULE=${{ github.event.inputs.filter }}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=12",
+    "node": ">=14.13.1",
     "npm": ">=6"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "remove": "grabthar-remove",
     "release": "grabthar-release",
     "postrelease": "npm run cdnify -- --commitonly",
-    "activate": "CDNIFY=false grabthar-activate",
+    "activate": "grabthar-activate --CDNIFY=false",
     "postactivate": "npm run cdnify -- --commitonly",
     "flatten": "grabthar-flatten",
     "full-release": "npm run upgrade && npm run release && npm run activate",


### PR DESCRIPTION
### Description
This PR is in anticipation of supporting the hopefully-soon-to-be-merged `zx` scripts in `grabthar-release`: https://github.com/krakenjs/grabthar-release/pull/17

### Why are we making these changes?
The version of `zx` that's pinned in the above `grabthar-release` PR requires node `^14.13.1` to work properly, and arg syntax has changed from `"activate": "CDNIFY=false grabthar-activate"` in Bash to `"activate": "grabthar-activate --CDNIFY=false"` in `zx`.

### Notes
It appears that our current `publish` and `activate` GitHub Actions workflows pull in the latest LTS version of node `14`, so I opted out of making any changes to `node-version` in those files.