### PR TITLE
Fix `upgrade` & `activate` workflow syntax

### DIFF
--- a/.github/workflows/activate.yml
+++ b/.github/workflows/activate.yml
@@ -32,7 +32,7 @@ jobs:
           git config --global user.name ${{ github.actor }}
 
       - name: Activate npm dist tags
-        run: npm run activate --LOCAL_VERSION=${{ github.event.inputs.version }}
+        run: npm run activate -- --LOCAL_VERSION=${{ github.event.inputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -31,4 +31,4 @@ jobs:
           git config --global user.name ${{ github.actor }}
 
       - name: 🍏 Upgrade dependencies
-        run: npm run upgrade --MODULE=${{ github.event.inputs.filter }}
+        run: npm run upgrade -- --MODULE=${{ github.event.inputs.filter }}


### PR DESCRIPTION
### Description

There's a syntax error in our `upgrade` and `activate` GitHub Actions workflows that results in not properly passing the command line args to the scripts themselves. We need to add the `--` separator to distinguish between the args passed to the npm command and the args passed to the scripts.