### PR TITLE
set versions to keep at 3 for cdnify

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "validate-components": "babel-node test/validate-components",
     "validate-components-for-publish": "babel-node test/validate-components-for-publish",
     "validate-flat": "babel-node test/validate-flat",
-    "cdnify": "grabthar-cdnify --recursive --cdn='https://www.paypalobjects.com'",
+    "cdnify": "grabthar-cdnify --recursive --cdn='https://www.paypalobjects.com' --versionsToKeep=3",
     "reinstall": "rm -f ./package-lock.json && rm -rf ./node_modules && npm install && git checkout package-lock.json && git checkout package.json",
     "flow-typed": "rm -rf ./flow-typed && flow-typed install",
     "lint": "eslint test/ *.js",
@@ -54,10 +54,10 @@
   "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "grabthar-release": "^1",
+    "@krakenjs/grabthar-release": "^2.0.0",
     "flow-bin": "0.135.0",
-    "grumbler-scripts": "^5",
-    "flowgen": "1.11.0"
+    "flowgen": "1.11.0",
+    "grumbler-scripts": "^5"
   },
   "dependencies": {
     "@paypal/card-components": "1.0.52",


### PR DESCRIPTION
this is to allow us to use previous script cache in clientsdknodeweb
https://github.com/krakenjs/grabthar-release/pull/18