### PR TITLE
fix: npm run reinstall deps

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -19,9 +19,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+        run: npm run reinstall
 
       - name: Configure git user
         run: |


### PR DESCRIPTION
### Purpose

Currently, our dry-run workflow leaves uncommitted/unstaged changes in source control while installing deps. This results in an error being thrown during `grabthar-release`. The solution to this is to run `npm run reinstall` instead of using `bahmutov/npm-install@v1`.