### PR TITLE
chore: remove postinstall step with web cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "postactivate": "npm run cdnify -- --commitonly",
     "flatten": "grabthar-flatten",
     "full-release": "npm run upgrade && npm run release && npm run activate",
-    "postinstall": "npm_config_registry=https://npm.paypal.com npm install @paypalcorp/web --no-save --proxy='null' --https-proxy='null' || echo 'Unable to install cdnx cli tools'",
     "prepublishOnly": "npm run validate-components-for-publish"
   },
   "files": [


### PR DESCRIPTION
We no longer need this postinstall step for the internal web cli. Removing it in favor of using GitHub Actions/Jenkins for the deployment process instead of the cli.