### PR TITLE
experimental versioned cdn flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "validate-components": "babel-node test/validate-components",
     "validate-components-for-publish": "babel-node test/validate-components-for-publish",
     "validate-flat": "babel-node test/validate-flat",
-    "cdnify": "grabthar-cdnify --recursive --cdn='https://www.paypalobjects.com' --versionsToKeep=3",
+    "cdnify": "grabthar-cdnify --recursive --cdn='https://www.paypalobjects.com' --versionsToKeep=1 --experimental-versioned-cdn",
     "reinstall": "rm -f ./package-lock.json && rm -rf ./node_modules && npm install && git checkout package-lock.json && git checkout package.json",
     "flow-typed": "rm -rf ./flow-typed && flow-typed install",
     "lint": "eslint test/ *.js",
@@ -54,7 +54,7 @@
   "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "@krakenjs/grabthar-release": "^2.0.0",
+    "@krakenjs/grabthar-release": "^2.3.0",
     "@krakenjs/grumbler-scripts": "^6.0.2",
     "eslint": "^8.13.0",
     "flow-bin": "0.135.0",


### PR DESCRIPTION
## Summary
implements this PR from grabthar-release: https://github.com/krakenjs/grabthar-release/pull/42

quick recap of that PR: start including a versioned folder of assets on the CDN so we can access `https://paypalobjects.com/js-sdk-release/5.0.311/`. Continue to overwrite/cleanup assets at the root of the `cdn` folder though so that the current systems that rely on unversioned assets to change will still work.

## Example Output
![Image 2022-05-10 at 12 53 09](https://user-images.githubusercontent.com/3527966/167692058-0b3bd5bb-fdeb-4d1e-8d0f-d08896090b22.jpg)

