### PR TITLE
feat: integrate legal component to sdk release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,14 @@
         "@paypal/sdk-logos": "^1.0.45"
       }
     },
+    "@paypal/legal-components": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@paypal/legal-components/-/legal-components-1.1.2.tgz",
+      "integrity": "sha512-0dVyroa/SP4vbzFvR1OHJBi5H7/VqHabWN4XHmupAO+0NU7xRZkAd4SnnfmSwPKgoMmY1Qe1pkDHbqg8o5AakQ==",
+      "requires": {
+        "@paypal/sdk-client": "^4.0.166"
+      }
+    },
     "@paypal/messaging-components": {
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/@paypal/messaging-components/-/messaging-components-1.35.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@paypal/example-components": "1.0.28",
     "@paypal/funding-components": "1.0.28",
     "@paypal/identity-components": "5.0.11",
+    "@paypal/legal-components": "1.1.2",
     "@paypal/messaging-components": "1.35.0",
     "@paypal/muse-components": "1.3.86",
     "@paypal/sdk-client": "4.0.167"


### PR DESCRIPTION
merged this PR a little too fast: https://github.com/paypal/paypal-sdk-release/pull/47

we are going to check with the APM team and make sure they are ready for this to go live come Wednesday