### PR TITLE
feat: upgrade to grumbler scripts 8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 module.exports = {
-    'extends': './node_modules/@krakenjs/grumbler-scripts/config/.eslintrc-node.js',
+    'extends': '@krakenjs/eslint-config-grumbler/eslintrc-node',
     'rules':   {
         'const-immutable/no-mutation': 'off'
     }

--- a/.flowconfig
+++ b/.flowconfig
@@ -6,7 +6,6 @@
 [include]
 [libs]
 flow-typed
-node_modules/grumbler-scripts/declarations.js
 node_modules/@paypal/sdk-client/src/declarations.js
 [options]
 module.name_mapper='^src\(.*\)$' -> '<PROJECT_ROOT>/src/\1'

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@krakenjs/babel-config-grumbler/babel-node"
+  "extends": "@krakenjs/babel-config-grumbler/babelrc-node"
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-    "extends": "@krakenjs/grumbler-scripts/config/.babelrc-node"
+  "extends": "@krakenjs/babel-config-grumbler/babel-node"
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,8 +1,8 @@
 /* @flow */
 /* eslint import/no-default-export: off */
 
-import { getKarmaConfig } from '@krakenjs/grumbler-scripts/config/karma.conf';
-import { getWebpackConfig } from '@krakenjs/grumbler-scripts/config/webpack.config';
+import { getKarmaConfig } from "@krakenjs/karma-config-grumbler";
+import { getWebpackConfig } from "@krakenjs/webpack-config-grumbler";
 
 export default function configKarma(karma : Object) {
 

--- a/package.json
+++ b/package.json
@@ -52,10 +52,13 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "@krakenjs/grabthar-release": "^3.0.0",
-    "@krakenjs/grumbler-scripts": "^6.0.2",
+    "@krakenjs/grumbler-scripts": "^8.0.3",
+    "cross-env": "^7.0.3",
     "eslint": "^8.13.0",
     "flow-bin": "0.135.0",
-    "flowgen": "1.11.0"
+    "flow-typed": "^3.8.0",
+    "flowgen": "1.11.0",
+    "jest": "^29.3.1"
   },
   "dependencies": {
     "@paypal/applepay-components": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "@krakenjs/grabthar-release": "^3.0.0",
-    "@krakenjs/grumbler-scripts": "^8.0.3",
+    "@krakenjs/grumbler-scripts": "^8.0.4",
     "cross-env": "^7.0.3",
     "eslint": "^8.13.0",
     "flow-bin": "0.135.0",


### PR DESCRIPTION
[DTPPSDK-939](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-939)

* Migrated to grumbler scripts v8.  
* Added `flow-typed`, `jest`, and `cross-env` as explicit dev-dependencies.

TODO: run Prettier?