### PR TITLE
Fix CI flow error

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 .*/node_modules/npm
 .*/node_modules/npmi
 .*/node_modules/resolve
+.*/node_modules/es-abstract
 [include]
 [libs]
 flow-typed


### PR DESCRIPTION
Fixes the failure from this CI run: https://github.com/paypal/paypal-sdk-release/actions/runs/8175424061
```
> @paypal/sdk-release@5.0.425 flow /home/runner/work/paypal-sdk-release/paypal-sdk-release
> flow check

Error ------------------------------------------------------------------- node_modules/es-abstract/tsconfig.tmp.json:1:1

Unexpected end of input, expected a valid JSON value

   1|
```