### PR TITLE
pin zoid version to 10.5.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
             echo "Error: Only @paypal packages are allowed."
             exit 1
           fi
-          npm run upgrade -- --MODULE="${FILTER}"
+          npm run upgrade -- --MODULE="${FILTER}" --REJECT="@krakenjs/zoid"
 
       - name: Publish to npm
         run: npm run release

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -42,4 +42,4 @@ jobs:
             echo "Error: Only @paypal packages are allowed."
             exit 1
           fi
-          npm run upgrade -- --MODULE="${FILTER}"
+          npm run upgrade -- --MODULE="${FILTER}" --REJECT="@krakenjs/zoid"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prettier": "2.8.4"
   },
   "dependencies": {
-    "@krakenjs/zoid": "10.5.2",
+    "@krakenjs/zoid": "10.5.0",
     "@paypal/googlepay-components": "1.3.5",
     "@paypal/applepay-components": "1.8.2",
     "@paypal/card-components": "1.0.56",


### PR DESCRIPTION
## Summary
- Pins `@krakenjs/zoid` to `10.5.0` in package.json
- Passes `--REJECT="@krakenjs/zoid"` in deploy and upgrade workflows to prevent grabthar-upgrade from bumping it back

Requires `@krakenjs/grabthar-release@3.10.1` which adds the `--REJECT` flag support.