### PR TITLE
unpin zoid

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -42,4 +42,4 @@ jobs:
             echo "Error: Only @paypal packages are allowed."
             exit 1
           fi
-          npm run upgrade -- --MODULE="${FILTER}" --REJECT="@krakenjs/zoid"
+          npm run upgrade -- --MODULE="${FILTER}"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ npm run upgrade @paypal/checkout-components
 npm run upgrade @paypal/card-components
 ```
 
+### Rejecting specific packages during upgrade
+
+Use `--REJECT` to exclude a package from being upgraded. This is useful when a package version needs to be pinned.
+
+```bash
+npm run upgrade -- --REJECT="@krakenjs/zoid"
+```
+
+To apply this via the GitHub Actions workflow, add `--REJECT="<package>"` to the `npm run upgrade` command in `.github/workflows/upgrade.yml`.
+
 ### Removing specific components
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "prettier": "2.8.4"
   },
   "dependencies": {
-    "@krakenjs/zoid": "10.5.0",
     "@paypal/googlepay-components": "1.3.5",
     "@paypal/applepay-components": "1.8.2",
     "@paypal/card-components": "1.0.58",


### PR DESCRIPTION
Removes the pinned `@krakenjs/zoid` version from package.json and the `--REJECT` flag from the upgrade workflow. Adds README docs on how to use `--REJECT` if a pin is needed again in the future.