### PR TITLE
pin @krakenjs/zoid to 10.5.0

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -42,4 +42,4 @@ jobs:
             echo "Error: Only @paypal packages are allowed."
             exit 1
           fi
-          npm run upgrade -- --MODULE="${FILTER}"
+          npm run upgrade -- --MODULE="${FILTER}" --REJECT="@krakenjs/zoid"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prettier": "2.8.4"
   },
   "dependencies": {
+    "@krakenjs/zoid": "10.5.0",
     "@paypal/googlepay-components": "1.3.5",
     "@paypal/applepay-components": "1.8.2",
     "@paypal/card-components": "1.0.59",


### PR DESCRIPTION
## What is the purpose of this PR?

Pins `@krakenjs/zoid` to version 10.5.0 in `package.json` and excludes it
from the automated upgrade workflow. This prevents zoid from being
automatically bumped while the pinned version is being validated.

**Jira Ticket:** N/A

## Type of change

- [ ] New feature (backward compatible change that adds new capability).
- [ ] UI change
- [ ] Bug fix.
- [ ] Breaking change (backward incompatible change). Provide references to customer impact and communication.
- [x] Refactor (no functional change)

## Testing Plan

Below is information that validates the successful implementation of this
feature and how a release manager can validate the success of a release
candidate in the absence of the PR author.

**PR Author:** [Nik Roman](https://paypal.enterprise.slack.com/team/U05UEBPF2P9)

**Backup Validator:** [Delaney Barrow](https://paypal.enterprise.slack.com/team/U08CJGPCH98)

**PR Author's Team:** PayPal JS SDK

**Test Environment URL:** N/A

### Step-by-Step Validation

1. Confirm `@krakenjs/zoid@10.5.0` is listed in `package.json` dependencies.
2. Confirm the upgrade workflow includes `--REJECT="@krakenjs/zoid"` so automated runs do not bump zoid.
3. Trigger a release and verify the published CDN packages include zoid 10.5.0.

### Rollback Considerations

Are there any services dependent on this change?

- [ ] Yes
- [x] No